### PR TITLE
Update basis_mat.py

### DIFF
--- a/GENetLib/basis_mat.py
+++ b/GENetLib/basis_mat.py
@@ -39,9 +39,9 @@ def bspline_mat(x, breaks, norder=4, nderiv=0, returnMatrix=False):
         if nbasis > 1:
             basismat = spline_design(knots, x, norder)
         else:
-            basismat = np.matrix(spline_design(knots, x, norder))
+            basismat = np.array(spline_design(knots, x, norder))
         if not returnMatrix and len(basismat.shape) == 2:
-            return np.matrix(basismat)
+            return np.array(basismat)
         else:
             return basismat
     else:


### PR DESCRIPTION
Hi, i find that in numpy >= 1.17, the 'np.matrix' method is deprecated, it needs to be changed into 'np.array'. 